### PR TITLE
auto configure tracing after RabbitAutoConfiguration.

### DIFF
--- a/opentracing-spring-rabbitmq-starter/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfiguration.java
+++ b/opentracing-spring-rabbitmq-starter/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfiguration.java
@@ -17,6 +17,8 @@ import io.opentracing.Tracer;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,8 +35,9 @@ import org.springframework.util.Assert;
  * @author Gilles Robert
  */
 @Configuration
+@AutoConfigureAfter(RabbitAutoConfiguration.class)
 @ConditionalOnClass({Message.class, RabbitTemplate.class})
-@ConditionalOnBean({Tracer.class})
+@ConditionalOnBean(Tracer.class)
 @ConditionalOnProperty(name = "opentracing.spring.rabbitmq.enabled", havingValue = "true", matchIfMissing = true)
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 public class RabbitMqTracingAutoConfiguration {


### PR DESCRIPTION
See https://github.com/opentracing-contrib/java-spring-rabbitmq/issues/33 and https://github.com/opentracing-contrib/java-spring-rabbitmq/issues/27
If no RabbitTemplate bean was declared, tracing was not triggered since the RabbitAutoConfiguration did not create the RabbitTemplate bean yet. This should fix it.