### PR TITLE
add missing method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Class | Method | Instrumented
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `void convertAndSend(Object message, MessagePostProcessor messagePostProcessor)` | &#10004;
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `void convertAndSend(String routingKey, Object message, MessagePostProcessor messagePostProcessor)` | &#10004;
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `void convertAndSend(String exchange, String routingKey, Object message, MessagePostProcessor messagePostProcessor)` |  &#10004;
+[AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `void convertAndSend(String exchange, String routingKey, Object message, @Nullable CorrelationData correlationData)` |  &#10004;
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `Message sendAndReceive(Message message)` | &#10004;
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `Message sendAndReceive(String routingKey, Message message)` | &#10004;
 [AmqpTemplate](https://docs.spring.io/spring-amqp/api/index.html?org/springframework/amqp/core/AmqpTemplate.html) | `Message sendAndReceive(String exchange, String routingKey, Message message)` | &#10004;

--- a/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationCustomizationItTest.java
+++ b/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationCustomizationItTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.junit.Test;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -185,6 +186,19 @@ public class RabbitMqTracingAutoConfigurationCustomizationItTest extends BaseRab
 
     // when
     rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, messagePostProcessor);
+
+    // then
+    FinishedSpansHelper spans = awaitFinishedSpans();
+    MockSpan sentSpan = spans.getSendSpan();
+    MockSpan receiveSpan = spans.getReceiveSpan();
+
+    assertOnSpans(sentSpan, receiveSpan, ROUTING_KEY);
+  }
+
+  @Test
+  public void convertAndSend_withExchangeRoutingKeyAndCorrelationData_shouldBeTraced() {
+    // when
+    rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, (CorrelationData) null);
 
     // then
     FinishedSpansHelper spans = awaitFinishedSpans();

--- a/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationDisabledItTest.java
+++ b/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationDisabledItTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -138,6 +139,15 @@ public class RabbitMqTracingAutoConfigurationDisabledItTest extends BaseRabbitMq
 
     // when
     rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, messagePostProcessor);
+
+    // then
+    checkNoSpans();
+  }
+
+  @Test
+  public void convertAndSend_withExchangeRoutingKeyAndCorrelationData_shouldNotBeTraced() {
+    // when
+    rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, (CorrelationData) null);
 
     // then
     checkNoSpans();

--- a/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationItTest.java
+++ b/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingAutoConfigurationItTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.junit.Test;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -149,6 +150,18 @@ public class RabbitMqTracingAutoConfigurationItTest extends BaseRabbitMqTracingI
 
     // when
     rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, messagePostProcessor);
+
+    // then
+    assertConsumerAndProducerSpans(0, ROUTING_KEY);
+  }
+
+
+  @Test
+  public void convertAndSend_withExchangeRoutingKeyAndCorrelationData_shouldBeTraced() {
+    // given
+    CorrelationData correlationData = null;
+    // when
+    rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, correlationData);
 
     // then
     assertConsumerAndProducerSpans(0, ROUTING_KEY);

--- a/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingManualConfigurationItTest.java
+++ b/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingManualConfigurationItTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -149,6 +150,15 @@ public class RabbitMqTracingManualConfigurationItTest extends BaseRabbitMqTracin
 
     // when
     rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, messagePostProcessor);
+
+    // then
+    assertConsumerAndProducerSpans(0, ROUTING_KEY);
+  }
+
+  @Test
+  public void convertAndSend_withExchangeRoutingKeyAndCorrelationData_shouldBeTraced() {
+    // when
+    rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, (CorrelationData) null);
 
     // then
     assertConsumerAndProducerSpans(0, ROUTING_KEY);

--- a/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingNoConfigurationItTest.java
+++ b/opentracing-spring-rabbitmq-it/src/test/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqTracingNoConfigurationItTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -139,6 +140,17 @@ public class RabbitMqTracingNoConfigurationItTest extends BaseRabbitMqTracingItT
 
     // when
     rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, messagePostProcessor);
+
+    // then
+    checkNoSpans();
+  }
+
+  @Test
+  public void convertAndSend_withExchangeRoutingKeyAndCorrelationData_shouldNotBeTraced() {
+    // given
+    CorrelationData correlationData = null;
+    // when
+    rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, MESSAGE, correlationData);
 
     // then
     checkNoSpans();

--- a/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqSendTracingAspect.java
+++ b/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqSendTracingAspect.java
@@ -161,6 +161,20 @@ class RabbitMqSendTracingAspect {
   }
 
   /**
+   * @see RabbitTemplate#convertAndSend(String, String, Object, CorrelationData)
+   */
+  @Around(value = "execution(* org.springframework.amqp.rabbit.core.RabbitTemplate.convertAndSend(..)) " +
+          "&& args(exchange, routingKey, message, correlationData)",
+          argNames = "pjp,exchange,routingKey,message,correlationData")
+  public Object traceRabbitConvertAndSend(ProceedingJoinPoint pjp, String exchange, String routingKey, Object message,
+                                          CorrelationData correlationData)
+          throws Throwable {
+    return createTracingHelper()
+            .doWithTracingHeadersMessage(exchange, routingKey, message, (convertedMessage) ->
+                    proceedReplacingMessage(pjp, convertedMessage, 2));
+  }
+
+  /**
    * @see org.springframework.amqp.core.AmqpTemplate#sendAndReceive(Message)
    */
   @Around(value = "execution(* org.springframework.amqp.core.AmqpTemplate.sendAndReceive(..))" +


### PR DESCRIPTION
To use with

 `RabbitTemplate.convertAndSend(String exchange, String routingKey, final Object object,@Nullable CorrelationData correlationData)`