### PR TITLE
Set necessary classes as public

### DIFF
--- a/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqBeanPostProcessor.java
+++ b/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqBeanPostProcessor.java
@@ -30,7 +30,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Gilles Robert
  * @author Sud Ramasamy
  */
-class RabbitMqBeanPostProcessor implements BeanPostProcessor {
+public class RabbitMqBeanPostProcessor implements BeanPostProcessor {
 
   private final RabbitMqReceiveTracingInterceptor rabbitMqReceiveTracingInterceptor;
 

--- a/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqReceiveTracingInterceptor.java
+++ b/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqReceiveTracingInterceptor.java
@@ -30,7 +30,7 @@ import org.springframework.aop.BeforeAdvice;
  * @author Gilles Robert
  */
 @AllArgsConstructor
-class RabbitMqReceiveTracingInterceptor implements MethodInterceptor, AfterAdvice, BeforeAdvice {
+public class RabbitMqReceiveTracingInterceptor implements MethodInterceptor, AfterAdvice, BeforeAdvice {
 
   private final Tracer tracer;
   private final RabbitMqSpanDecorator spanDecorator;

--- a/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqSendTracingAspect.java
+++ b/opentracing-spring-rabbitmq/src/main/java/io/opentracing/contrib/spring/rabbitmq/RabbitMqSendTracingAspect.java
@@ -29,7 +29,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
  */
 @Aspect
 @AllArgsConstructor
-class RabbitMqSendTracingAspect {
+public class RabbitMqSendTracingAspect {
 
   private final Tracer tracer;
   private final String exchange;


### PR DESCRIPTION
This will allow the usage of this library without the Spring Boot AutoConfiguration and allow users to manually config necessary beans.